### PR TITLE
Fix webfont 404 errors and update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy_jekyll_site.yml
+++ b/.github/workflows/deploy_jekyll_site.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
         with:
@@ -35,7 +35,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -43,7 +43,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/on_ndex_map_change.yml
+++ b/.github/workflows/on_ndex_map_change.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/on_pfocr_curation_rds.yml
+++ b/.github/workflows/on_pfocr_curation_rds.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/on_wpid_map_change.yml
+++ b/.github/workflows/on_wpid_map_change.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/favicon-16x16.png">
     <link rel="manifest" href="/assets/img/site.webmanifest">
     <link rel="shortcut icon" href="/assets/img/favicon.ico">
-    <link href="/assets/fontawesome.all.min.css" rel="stylesheet">
     <!-- Bootstrap -->
       <script src="https://code.jquery.com/jquery-3.5.1.js" type="text/javascript"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Problem
Two pre-existing issues were identified:

1. **Broken webfont references**: `fontawesome.all.min.css` was loaded locally but its 
   required `assets/webfonts/` directory was never committed to the repo, causing 404 
   errors in the browser console on every page load. A Font Awesome CDN link was already 
   present and serving icons correctly, making the local file redundant.

2. **Deprecated GitHub Actions**: All workflows were using Node.js 20-based action 
   versions, which are deprecated and will stop working on GitHub runners after 
   September 16, 2026.

## Fix
- Removed the broken `<link href="/assets/fontawesome.all.min.css">` from `_includes/head.html`
- Updated all workflow actions to latest Node.js 24-compatible versions:
  - `actions/checkout` v3 → v4
  - `actions/configure-pages` v2/v3 → v5
  - `actions/upload-pages-artifact` v1/v2 → v3
  - `actions/deploy-pages` v1/v2 → v4